### PR TITLE
Ensure JWT secret configured via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for gql-api-dleonsystems-webpage
+# Copy this file to src/.env and adjust values as needed
+
+# Secret used to sign JWT tokens
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # gql-api-dleonsystems-webpage
- gql-api-dleonsystems-webpage
+gql-api-dleonsystems-webpage
+
+## Environment variables
+
+The server requires a `JWT_SECRET` value to sign and verify JSON Web Tokens.
+Create a `src/.env` file (see `.env.example`) or set the variable in your
+environment before starting the server.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,7 +4,7 @@ if (process.env.NODE_ENV !== 'production') {
     const environment = environments;
 }
 export const ELASTIC_EMAIL_API_KEY = process.env.ELASTIC_EMAIL_API_KEY ?? ''; // Coloca tu API Key aquí
-export const SECRET_KEY = process.env.SECRET ?? '';
+export const SECRET_KEY = process.env.JWT_SECRET ?? '';
 export const HOSTMYSQL= process.env.HOSTMYSQL ?? 'localhost';
 export const USERMYSQL= process.env.USERMYSQL ?? 'root';
 export const PASSWORDMYSQL= process.env.PASSWORDMYSQL ?? '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ interface MyContext {
 
 // 🔧 Función principal para iniciar el servidor
 const startServer = async () => {
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required');
+  }
+
   const app = express();
 
   const mongoDb = await connectToMongo(); // <-- 4. CONECTAR ANTES DE INICIAR

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 
-const SECRET_KEY = process.env.JWT_SECRET || 'secreto_super_seguro';
+const SECRET_KEY = process.env.JWT_SECRET as string;
 
 /**
  * Middleware para validar y decodificar el token JWT

--- a/src/resolvers/mutations.ts
+++ b/src/resolvers/mutations.ts
@@ -6,7 +6,7 @@ import dotenv from 'dotenv';
 import { renderCorreoRegistro } from '../templates/renderCorreo';
 import { enviarCorreoCancelacion, enviarCorreoListaEspera, enviarCorreoRegistro } from '../lib/enviarCorreo';
 
-const SECRET_KEY = process.env.JWT_SECRET || 'secreto_super_seguro';
+const SECRET_KEY = process.env.JWT_SECRET as string;
 const RECAPTCHA_SECRET = process.env.RECAPTCHA_SECRET ?? 'TU_SECRET_KEY';
 async function validarReCaptcha(token: string) {
     try {


### PR DESCRIPTION
## Summary
- load JWT secret from environment without fallback
- fail fast at startup when JWT_SECRET is missing
- document the new JWT_SECRET requirement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687344ba2db883309508c07a477a0f68