### PR TITLE
Add Jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # gql-api-dleonsystems-webpage
- gql-api-dleonsystems-webpage
+
+gql-api-dleonsystems-webpage
+
+## Running tests
+
+Install dependencies and run the test suite using:
+
+```bash
+npm install
+npm test
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "API graphql-project-dleonsystems-web page",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node dist/index.js",
     "build": "tsc && npm run copy:graphql",
     "copy:graphql": "cpx \"src/graphql/**/*.graphql\" dist/graphql",
@@ -47,6 +47,9 @@
     "cpx": "^1.5.0",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/tests/jwt.test.ts
+++ b/tests/jwt.test.ts
@@ -1,0 +1,15 @@
+import JWT from '../src/lib/jwt';
+
+beforeAll(() => {
+  process.env.SECRET = 'testsecret';
+  process.env.DURACIONTOKEN = '3600';
+});
+
+describe('JWT helper', () => {
+  it('signs and verifies tokens', () => {
+    const jwtHelper = new JWT();
+    const token = jwtHelper.sign({ user: 'tester' });
+    const decoded: any = jwtHelper.verify(token);
+    expect((decoded as any).user).toBe('tester');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as dev dependency and configure it
- add sample JWT test
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734502c3008330a74231005fe3e453