### PR TITLE
Add configurable request size limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables
+PORT=5005
+DB=postgres://user:password@localhost:5432/dbname
+MONGO_URI=mongodb://127.0.0.1:27017
+MONGO_DBNAME=miProyectoDB
+
+# Request size limits
+JSON_LIMIT=20mb
+URLENCODED_LIMIT=50mb

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # gql-api-dleonsystems-webpage
- gql-api-dleonsystems-webpage
+GraphQL API for the dleonsystems webpage.
+
+## Environment variables
+
+Create a `.env` file based on `.env.example` and adjust the values as needed.
+
+- `JSON_LIMIT` sets the maximum size accepted by `bodyParser.json`. Defaults to
+  `20mb`.
+- `URLENCODED_LIMIT` sets the limit for `bodyParser.urlencoded`. Defaults to
+  `50mb`.
+
+Additional variables such as database or mail credentials may be required
+depending on your setup. Review the source code for the complete list.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,11 @@ const startServer = async () => {
   const mongoDb = await connectToMongo(); // <-- 4. CONECTAR ANTES DE INICIAR
 
 
-  // Aumentar límites de tamaño de solicitudes
-  app.use(bodyParser.json({ limit: '20mb' })); // ❗ Evaluar si el límite de 20mb es necesario o excesivo
-  app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
+  // Aumentar límites de tamaño de solicitudes usando variables de entorno
+  const jsonLimit = process.env.JSON_LIMIT || '20mb';
+  const urlencodedLimit = process.env.URLENCODED_LIMIT || '50mb';
+  app.use(bodyParser.json({ limit: jsonLimit }));
+  app.use(bodyParser.urlencoded({ limit: urlencodedLimit, extended: true }));
 
   // Confía en proxies (para obtener IP real si hay load balancer)
   app.set('trust proxy', true); // ✅ Buen uso para setups detrás de un proxy


### PR DESCRIPTION
## Summary
- read JSON_LIMIT and URLENCODED_LIMIT from environment
- document new variables
- provide an `.env.example`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687344f8b4008330a0b5fedfc3f55d71