### PR TITLE
Fix Express import syntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
-const express = require('express'); // ❗ Reemplazar `require` con `import` por consistencia
+import express from 'express'; // ❗ Reemplazar `require` con `import` por consistencia
 import cors from 'cors';
 import bodyParser from 'body-parser';
 


### PR DESCRIPTION
## Summary
- swap require for ES module import of Express
- confirm CommonJS module type and ES module interoperability are enabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687344e8e2908330a24915496f6235c0