### PR TITLE
Replace console logs with logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # gql-api-dleonsystems-webpage
- gql-api-dleonsystems-webpage
+gql-api-dleonsystems-webpage
+
+## Logging
+
+Logs are controlled by a `LOG_LEVEL` environment variable. Valid levels are
+`error`, `warn`, `info` and `debug` (default is `info`).

--- a/src/config/db-mongo.ts
+++ b/src/config/db-mongo.ts
@@ -1,5 +1,6 @@
 // src/config/db-mongo.ts
 import { MongoClient, Db } from 'mongodb';
+import logger from '../lib/logger';
 
 // Lee las variables de entorno para la conexión
 const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017';
@@ -20,10 +21,10 @@ export const connectToMongo = async (): Promise<Db> => {
     const client = new MongoClient(MONGO_URI);
     await client.connect();
     db = client.db(MONGO_DBNAME);
-    console.log(`✅ Conectado a la base de datos MongoDB: ${MONGO_DBNAME}`);
+    logger.info(`✅ Conectado a la base de datos MongoDB: ${MONGO_DBNAME}`);
     return db;
   } catch (error) {
-    console.error('❌ Error al conectar con MongoDB:', error);
+    logger.error('❌ Error al conectar con MongoDB:', error);
     process.exit(1); // Detiene la aplicación si la conexión a la DB falla
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import bodyParser from 'body-parser';
 
 import { typeDefs } from './schema/loadSchema';
 import { resolvers } from './resolvers';
+import logger from './lib/logger';
 import { ps } from './config/db-pg';
 import { connectToMongo } from './config/db-mongo'; // <-- 1. IMPORTAR
 import { Db } from 'mongodb';                       // <-- 2. IMPORTAR TIPO
@@ -70,12 +71,12 @@ const startServer = async () => {
 
   // 🚀 Iniciar servidor en puerto XXXX
   const port = process.env.PORT || 5005; // ✅ Extraer el puerto a una constante para mayor claridad
-  app.listen(port, () => {
-    console.log(`🚀 Servidor listo en http://localhost:${port}/graphql`);
-  });
+    app.listen(port, () => {
+      logger.info(`🚀 Servidor listo en http://localhost:${port}/graphql`);
+    });
 };
 
 // Manejo de errores global: Atrapar errores que puedan ocurrir durante el inicio del servidor
 startServer().catch((error) => {
-  console.error('❌ Error al iniciar el servidor:', error);
+  logger.error('❌ Error al iniciar el servidor:', error);
 });

--- a/src/lib/enviarCorreo.ts
+++ b/src/lib/enviarCorreo.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { renderCorreoRegistro } from '../templates/renderCorreo';
 import { renderCorreoCancelacion } from '../templates/cancelacionCorreo';
 import { renderCorreoListaEspera } from '../templates/listaEsperaCorreo';
+import logger from './logger';
 
 export async function enviarCorreoRegistro(userCheck: any) {
     try {
@@ -25,11 +26,11 @@ export async function enviarCorreoRegistro(userCheck: any) {
                 headers: { 'Content-Type': 'application/json' },
             }
         );
-        console.log('Correo enviado:', response.data);
+        logger.info('Correo enviado:', response.data);
         return response.data;
 
     } catch (err) {
-        console.error('❌ Error al enviar correo:', err);
+        logger.error('❌ Error al enviar correo:', err);
         throw new Error('Fallo en el envío del correo de confirmación');
     }
 }
@@ -55,11 +56,11 @@ export async function enviarCorreoCancelacion(userCheck: any) {
                 headers: { 'Content-Type': 'application/json' },
             }
         );
-        console.log('Correo enviado:', await response.data);
+        logger.info('Correo enviado:', await response.data);
         return response.data;
 
     } catch (err) {
-        console.error('❌ Error al enviar correo:', err);
+        logger.error('❌ Error al enviar correo:', err);
         throw new Error('Fallo en el envío del correo de confirmación');
     }
 }
@@ -85,11 +86,11 @@ export async function enviarCorreoListaEspera(userCheck: any) {
                 headers: { 'Content-Type': 'application/json' },
             }
         );
-        console.log('Correo enviado:', response.data);
+        logger.info('Correo enviado:', response.data);
         return response.data;
 
     } catch (err) {
-        console.error('❌ Error al enviar correo:', err);
+        logger.error('❌ Error al enviar correo:', err);
         throw new Error('Fallo en el envío del correo de confirmación');
     }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,35 @@
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+const levelEnv = (process.env.LOG_LEVEL || 'info').toLowerCase();
+const currentLevel: LogLevel =
+  levelEnv === 'debug' || levelEnv === 'info' || levelEnv === 'warn' || levelEnv === 'error'
+    ? (levelEnv as LogLevel)
+    : 'info';
+
+const levels: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+function shouldLog(lvl: LogLevel): boolean {
+  return levels[lvl] <= levels[currentLevel];
+}
+
+const logger = {
+  error: (...args: any[]) => {
+    if (shouldLog('error')) console.error(...args);
+  },
+  warn: (...args: any[]) => {
+    if (shouldLog('warn')) console.warn(...args);
+  },
+  info: (...args: any[]) => {
+    if (shouldLog('info')) console.log(...args);
+  },
+  debug: (...args: any[]) => {
+    if (shouldLog('debug')) console.debug(...args);
+  },
+};
+
+export default logger;

--- a/src/lib/mail-elastic.ts
+++ b/src/lib/mail-elastic.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import FormData from 'form-data';
 import fs from 'fs';
 import { ELASTIC_EMAIL_API_KEY } from '../config/constants';
+import logger from './logger';
 
 
 
@@ -51,9 +52,9 @@ export async function sendEmail({
       formData,
       { headers: { ...formData.getHeaders() } }
     );
-    // console.log(`Correo enviado exitosamente a ${recipientName}:`, response.data);
+      // logger.debug(`Correo enviado exitosamente a ${recipientName}:`, response.data);
   } catch (error) {
     const err = error as any;
-    console.error('Error al enviar el correo:', err.response?.data || err.message);
+      logger.error('Error al enviar el correo:', err.response?.data || err.message);
   }
 }

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -1,6 +1,7 @@
 // src/lib/mails.ts
 import nodemailer from 'nodemailer';
 import dotenv from 'dotenv';
+import logger from './logger';
 
 dotenv.config();
 
@@ -25,8 +26,8 @@ export const enviarCorreo = async (to: string, subject: string, text: string) =>
   try {
     const result = await transporter.sendMail(mailOptions);
     return result;
-  } catch (error) {
-    console.error('❌ Error al enviar correo:', error);
+    } catch (error) {
+      logger.error('❌ Error al enviar correo:', error);
     throw error;
   }
 };

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import logger from '../lib/logger';
 
 const SECRET_KEY = process.env.JWT_SECRET || 'secreto_super_seguro';
 
@@ -18,7 +19,7 @@ export const authMiddleware = async ({ req }: { req: any }) => {
 
     try {
         const decoded: any = jwt.verify(token.replace('Bearer ', ''), SECRET_KEY);
-        console.log({
+        logger.debug({
             usuarioId: decoded.usuarioId,
             rol: decoded.rol,
             db: req.db
@@ -29,7 +30,7 @@ export const authMiddleware = async ({ req }: { req: any }) => {
             db: req.db
         };
     } catch (error) {
-        console.error('Error validando token JWT:', error);
+        logger.error('Error validando token JWT:', error);
         return { usuarioId: null, rol: null, db: req.db };
     }
 };

--- a/src/middlewares/recaptcha.ts
+++ b/src/middlewares/recaptcha.ts
@@ -1,5 +1,6 @@
 import { RecaptchaEnterpriseServiceClient } from '@google-cloud/recaptcha-enterprise';
 import dotenv from 'dotenv';
+import logger from '../lib/logger';
 dotenv.config();
 
 export async function verificarTokenReCaptcha(token: string): Promise<boolean> {
@@ -27,18 +28,18 @@ export async function verificarTokenReCaptcha(token: string): Promise<boolean> {
     const score = response.riskAnalysis?.score ?? 0;
 
     if (!valid) {
-      console.error('Token inválido:', response.tokenProperties?.invalidReason);
+      logger.error('Token inválido:', response.tokenProperties?.invalidReason);
       return false;
     }
 
     if (action !== expectedAction && action !== expectedAction2) {
-      console.warn(`Acción esperada "${expectedAction}" o "${expectedAction2}", pero se recibió: "${action}"`);
+      logger.warn(`Acción esperada "${expectedAction}" o "${expectedAction2}", pero se recibió: "${action}"`);
       return false;
     }
 
     return score >= 0.5;
   } catch (err) {
-    console.error('Error en evaluación reCAPTCHA Enterprise:', err);
+    logger.error('Error en evaluación reCAPTCHA Enterprise:', err);
     return false;
   }
 }

--- a/src/resolvers/mutations.ts
+++ b/src/resolvers/mutations.ts
@@ -3,6 +3,7 @@ import { verificarTokenReCaptcha } from '../middlewares/recaptcha';
 import JWT from '../lib/jwt';
 import axios from 'axios';
 import dotenv from 'dotenv';
+import logger from '../lib/logger';
 import { renderCorreoRegistro } from '../templates/renderCorreo';
 import { enviarCorreoCancelacion, enviarCorreoListaEspera, enviarCorreoRegistro } from '../lib/enviarCorreo';
 
@@ -19,12 +20,12 @@ async function validarReCaptcha(token: string) {
         }
         return { success: true };
     } catch (err) {
-        console.error('Error validando reCAPTCHA:', err);
+        logger.error('Error validando reCAPTCHA:', err);
         return { success: false, message: 'No se pudo verificar el CAPTCHA' };
     }
 }
 function manejarError(error: any, mensaje: string) {
-    console.error(mensaje, error);
+    logger.error(mensaje, error);
     return { status: false, message: mensaje, data: null };
 }
 
@@ -44,7 +45,7 @@ export const mutationResolvers = {
                   if (!captcha.success)
                     return { status: false, message: captcha.message, data: null };
                 } catch (err) {
-                  console.error('Error validando reCAPTCHA:', err);
+                  logger.error('Error validando reCAPTCHA:', err);
                   return {
                     status: false,
                     message: 'No se pudo verificar el CAPTCHA',
@@ -102,7 +103,7 @@ export const mutationResolvers = {
                     usuario: newUser,
                 };
             } catch (error) {
-                console.error('Error al crear usuario:', error);
+                logger.error('Error al crear usuario:', error);
                 return manejarError(error, 'Error al crear usuario');
             }
         },
@@ -124,7 +125,7 @@ export const mutationResolvers = {
                     if (!captcha.success)
                         return { status: false, message: captcha.message, data: null };
                 } catch (err) {
-                    console.error('Error validando reCAPTCHA:', err);
+                    logger.error('Error validando reCAPTCHA:', err);
                     return {
                         status: false,
                         message: 'No se pudo verificar el CAPTCHA',
@@ -156,7 +157,7 @@ export const mutationResolvers = {
                     usuario: null,
                 };
             } catch (error) {
-                console.error('Error al crear usuario:', error);
+                logger.error('Error al crear usuario:', error);
                 return { status: false, message: 'Error al crear usuario', user: null };
             }
         },
@@ -178,7 +179,7 @@ export const mutationResolvers = {
                     if (!captcha.success)
                         return { status: false, message: captcha.message, data: null };
                 } catch (err) {
-                    console.error('Error validando reCAPTCHA:', err);
+                    logger.error('Error validando reCAPTCHA:', err);
                     return {
                         status: false,
                         message: 'No se pudo verificar el CAPTCHA',
@@ -199,7 +200,7 @@ export const mutationResolvers = {
                         };
                     }
                 } catch (error) {
-                    console.error('Error al verificar el token:', error);
+                    logger.error('Error al verificar el token:', error);
                     return {
                         status: false,
                         message: 'Error al verificar el token',
@@ -294,7 +295,7 @@ export const mutationResolvers = {
                     usuario: updatedUser,
                 };
             } catch (error) {
-                console.error('Error al crear usuario:', error);
+                logger.error('Error al crear usuario:', error);
                 return manejarError(error, 'Error al actualizar usuario');
             }
         },
@@ -312,7 +313,7 @@ export const mutationResolvers = {
                     if (!captcha.success)
                         return { status: false, message: captcha.message, data: null };
                 } catch (err) {
-                    console.error('Error validando reCAPTCHA:', err);
+                    logger.error('Error validando reCAPTCHA:', err);
                     return {
                         status: false,
                         message: 'No se pudo verificar el CAPTCHA',
@@ -347,7 +348,7 @@ export const mutationResolvers = {
                     usuario: user,
                 };
             } catch (error) {
-                console.error('Error al iniciar sesión:', error);
+                logger.error('Error al iniciar sesión:', error);
                 return manejarError(error, 'Error al iniciar sesión');
             }
         },
@@ -366,7 +367,7 @@ export const mutationResolvers = {
                     return { status: false, message: captcha.message, data: null };
                 }
             } catch (err) {
-                console.error('Error validando reCAPTCHA:', err);
+                logger.error('Error validando reCAPTCHA:', err);
                 return manejarError(err, 'No se pudo verificar el CAPTCHA');
             }
 
@@ -485,7 +486,7 @@ export const mutationResolvers = {
                         enlaceEvento: `http://qa.cerrarlabrecha.sep.gob.mx/eventos/${eventoId}`,
                     });
                 } catch (error) {
-                    console.error('Error al enviar correo de confirmación:', error);
+                    logger.error('Error al enviar correo de confirmación:', error);
                     return manejarError(error, 'Error al enviar correo de confirmación');
                 }
 
@@ -496,7 +497,7 @@ export const mutationResolvers = {
                 };
 
             } catch (error) {
-                console.error('❌ Error al crear registro:', error);
+                logger.error('❌ Error al crear registro:', error);
                 return manejarError(error, 'Error al crear registro');
             }
         },
@@ -577,8 +578,8 @@ export const mutationResolvers = {
             FROM "Evento" WHERE "Oid" = $1 AND "GCRecord" IS NULL`,
                     [cancelacion.eventoId]
                 );
-                console.log('usuario', usuario);
-                console.log('evento', evento);
+                logger.debug('usuario', usuario);
+                logger.debug('evento', evento);
                 if (usuario || evento) {
                      enviarCorreoCancelacion({
                         nombreRepresentante: `${usuario.nombre} ${usuario.apellidoPaterno} ${usuario.apellidoMaterno}`,
@@ -592,7 +593,7 @@ export const mutationResolvers = {
                     cancelacion: registro,
                 };
             } catch (error) {
-                console.error('❌ Error al cancelar registro:', error);
+                logger.error('❌ Error al cancelar registro:', error);
                 return manejarError(error, 'Error al cancelar registro');
             }
         },
@@ -630,7 +631,7 @@ export const mutationResolvers = {
                     documento: result,
                 };
             } catch (error) {
-                console.error('❌ Error al cargar documento:', error);
+                logger.error('❌ Error al cargar documento:', error);
                 return manejarError(error, 'Error al cargar documento');
             }
         },
@@ -660,7 +661,7 @@ export const mutationResolvers = {
                     respuesta: result,
                 };
             } catch (error) {
-                console.error('❌ Error al registrar respuesta:', error);
+                logger.error('❌ Error al registrar respuesta:', error);
                 return manejarError(error, 'Error al registrar respuesta');
             }
         },
@@ -711,8 +712,8 @@ export const mutationResolvers = {
             FROM "Evento" WHERE "Oid" = $1 AND "GCRecord" IS NULL`,
                     [eventoId]
                 );
-                console.log('usuario', usuario);
-                console.log('evento', evento);
+                logger.debug('usuario', usuario);
+                logger.debug('evento', evento);
                 if (usuario || evento) {
                     enviarCorreoListaEspera({
                         nombreRepresentante: `${usuario.nombre} ${usuario.apellidoPaterno} ${usuario.apellidoMaterno}`,
@@ -726,7 +727,7 @@ export const mutationResolvers = {
                     listaEspera: [result],
                 };
             } catch (error) {
-                console.error('❌ Error al registrar en lista de espera:', error);
+                logger.error('❌ Error al registrar en lista de espera:', error);
                 return manejarError(error, 'Error al registrar en lista de espera');
             }
         },

--- a/src/resolvers/queries.ts
+++ b/src/resolvers/queries.ts
@@ -1,5 +1,6 @@
 import JWT from "../lib/jwt";
 import { Db } from 'mongodb'; // <-- IMPORTANTE: Importar el tipo Db
+import logger from '../lib/logger';
 
 export const queryResolvers = {
     Query: {
@@ -13,7 +14,7 @@ export const queryResolvers = {
                 const testimonialsData = await collection.find({}).toArray();
                 return testimonialsData;
             } catch (error) {
-                console.error('❌ Error al consultar testimonios:', error);
+                logger.error('❌ Error al consultar testimonios:', error);
                 // Puedes retornar un array vacío o lanzar un error de GraphQL
                 return [];
             }
@@ -32,7 +33,7 @@ export const queryResolvers = {
                 // Devuelve el array que está bajo la clave 'es'
                 return data ? data.es : []; 
             } catch (error) {
-                console.error('❌ Error al consultar casos de éxito:', error);
+                logger.error('❌ Error al consultar casos de éxito:', error);
                 return [];
             }
         },
@@ -46,7 +47,7 @@ export const queryResolvers = {
                 // Devuelve el array bajo la clave del idioma solicitado ('es' o 'en')
                 return data && data[language] ? data[language] : [];
             } catch (error) {
-                console.error('❌ Error al consultar el portafolio:', error);
+                logger.error('❌ Error al consultar el portafolio:', error);
                 return [];
             }
         },
@@ -61,7 +62,7 @@ export const queryResolvers = {
                 // Devuelve el objeto completo bajo la clave del idioma solicitado
                 return data && data[language] ? data[language] : null;
             } catch (error) {
-                console.error('❌ Error al consultar los servicios:', error);
+                logger.error('❌ Error al consultar los servicios:', error);
                 return null;
             }
         },
@@ -77,7 +78,7 @@ export const queryResolvers = {
                 const blogData = data[0];
                 return blogData && blogData[language] ? blogData[language] : [];
             } catch (error) {
-                console.error('❌ Error al consultar el blog:', error);
+                logger.error('❌ Error al consultar el blog:', error);
                 return [];
             }
         },
@@ -104,7 +105,7 @@ export const queryResolvers = {
                     configuraciones
                 };
             } catch (error) {
-                console.error('❌ Error al consultar configuración:', error);
+                logger.error('❌ Error al consultar configuración:', error);
                 return {
                     status: false,
                     message: 'Error al consultar configuración',
@@ -146,7 +147,7 @@ export const queryResolvers = {
                     eventos
                 }
             } catch (error) {
-                console.error('❌ Error en resolver eventos:', error);
+                logger.error('❌ Error en resolver eventos:', error);
 
                 return {
                     status: false,
@@ -183,7 +184,7 @@ export const queryResolvers = {
             FROM "Evento"
             WHERE "Oid" = $1 AND "GCRecord" IS NULL
           `, [args.id]);
-                if (!evento) console.warn('⚠️ Evento no encontrado:', args.id);
+                if (!evento) logger.warn('⚠️ Evento no encontrado:', args.id);
 
                 return {
                     status: true,
@@ -191,7 +192,7 @@ export const queryResolvers = {
                     eventos: [evento]
                 }
             } catch (error) {
-                console.error('❌ Error al obtener evento por ID:', error);
+                logger.error('❌ Error al obtener evento por ID:', error);
 
                 return {
                     status: false,
@@ -236,7 +237,7 @@ export const queryResolvers = {
                     usuarios
                 }
             } catch (error) {
-                console.error('❌ Error al consultar usuarios:', error);
+                logger.error('❌ Error al consultar usuarios:', error);
                 return {
                     status: false,
                     message: 'Error al consultar usuarios',
@@ -268,7 +269,7 @@ export const queryResolvers = {
                     registros
                 }
             } catch (error) {
-                console.error('❌ Error al consultar registros del usuario:', error);
+                logger.error('❌ Error al consultar registros del usuario:', error);
                 return {
                     status: false,
                     message: 'Error al consultar registros del usuario',
@@ -304,7 +305,7 @@ export const queryResolvers = {
                     cancelaciones
                 }
             } catch (error) {
-                console.error('❌ Error al consultar cancelaciones del usuario:', error);
+                logger.error('❌ Error al consultar cancelaciones del usuario:', error);
                 return {
                     status: false,
                     message: 'Error al consultar cancelaciones del usuario',
@@ -336,7 +337,7 @@ export const queryResolvers = {
                     archivos
                 };
             } catch (error) {
-                console.error('Error en archivosPorEvento:', error);
+                logger.error('Error en archivosPorEvento:', error);
                 return {
                     status: false,
                     message: 'Error al consultar archivos del evento',
@@ -368,7 +369,7 @@ export const queryResolvers = {
                     documentos
                 }
             } catch (error) {
-                console.error('❌ Error al consultar documentos del usuario:', error);
+                logger.error('❌ Error al consultar documentos del usuario:', error);
                 return {
                     status: false,
                     message: 'Error al consultar documentos del usuario',
@@ -432,7 +433,7 @@ export const queryResolvers = {
                 };
 
             } catch (error) {
-                console.error('Error en listaEsperaPorEvento:', error);
+                logger.error('Error en listaEsperaPorEvento:', error);
                 return {
                     status: false,
                     message: 'Error al consultar la lista de espera',
@@ -471,7 +472,7 @@ export const queryResolvers = {
                     usuarios: [usuario]
                 }
             } catch (error) {
-                console.error('Error en usuario:', error);
+                logger.error('Error en usuario:', error);
                 return {
                     status: false,
                     message: 'Error al consultar el usuario',
@@ -485,7 +486,7 @@ export const queryResolvers = {
                 const estados = await ps.manyOrNone('SELECT id, "NombreEstado" as "nombreEstado", "CodigoEstado" as "codigoEstado" FROM "Estados" ORDER BY "NombreEstado"');
                 return { status: true, message: "Resultado de estados", estados };
             } catch (error) {
-                console.error('Error en estados:', error);
+                logger.error('Error en estados:', error);
                 return {
                     status: false,
                     message: 'Error al consultar estados',
@@ -499,7 +500,7 @@ export const queryResolvers = {
                 const estado = await ps.oneOrNone('SELECT id, "NombreEstado" as "nombreEstado", "CodigoEstado" as "codigoEstado" FROM "Estados" WHERE id = $1', [id]);
                 return { status: true, message: "Resultado de estados", estados: [estado] };
             } catch (error) {
-                console.error('Error en estado:', error);
+                logger.error('Error en estado:', error);
                 return {
                     status: false,
                     message: 'Error al consultar estado',
@@ -513,7 +514,7 @@ export const queryResolvers = {
                 const municipios = await ps.any('SELECT id, "CodigoMunicipio" as "codigoMunicipio", "NombreMunicipio" as "nombreMunicipio", "EstadoId" as "estadoId" FROM "Municipios" ORDER BY "NombreMunicipio"');
                 return { status: true, message: "Resultado de municipios", municipios };
             } catch (error) {
-                console.error('Error en municipios:', error);
+                logger.error('Error en municipios:', error);
                 return {
                     status: false,
                     message: 'Error al consultar municipios',
@@ -532,7 +533,7 @@ export const queryResolvers = {
                     status: true, message: "Resultado de municipios", municipios
                 };
             } catch (error) {
-                console.error('Error en municipiosPorEstado:', error);
+                logger.error('Error en municipiosPorEstado:', error);
                 return {
                     status: false,
                     message: 'Error al consultar municipios por estado',
@@ -546,7 +547,7 @@ export const queryResolvers = {
                 const colonias = await ps.any('SELECT id, "CodigoPostal" as "codigoPostal", "NombreColonia", as "nombreColonia", "MunicipioId" as "municipioId" FROM "Colonias" ORDER BY "NombreColonia"');
                 return { status: true, message: "Resultado de colonias", colonias };
             } catch (error) {
-                console.error('Error en colonias:', error);
+                logger.error('Error en colonias:', error);
                 return {
                     status: false,
                     message: 'Error al consultar colonias',
@@ -565,7 +566,7 @@ export const queryResolvers = {
                     status: true, message: "Resultado de colonias", colonias
                 };
             } catch (error) {
-                console.error('Error en coloniasPorMunicipio:', error);
+                logger.error('Error en coloniasPorMunicipio:', error);
                 return {
                     status: false,
                     message: 'Error al consultar colonias por municipio',

--- a/src/resolvers/types.ts
+++ b/src/resolvers/types.ts
@@ -1,4 +1,5 @@
 import { connectionString } from '../config/db-pg';
+import logger from '../lib/logger';
 export const typeResolvers = {
   Evento: {
     async cupoDisponible(
@@ -17,7 +18,7 @@ SELECT COUNT(*) as "inscritos" FROM "RegistroEvento" WHERE "Evento" = $1 AND "Ca
           parseInt(parent.capacidadMaxima, 10) - parseInt(cupo.inscritos, 10)
         );
       } catch (error) {
-        console.error('Error fetching cupoDisponible:', error);
+        logger.error('Error fetching cupoDisponible:', error);
         throw new Error('Error fetching cupoDisponible');
       }
     },
@@ -40,7 +41,7 @@ ORDER BY "Fecha" DESC
         );
         return eventos;
       } catch (error) {
-        console.error('Error fetching eventos:', error);
+        logger.error('Error fetching eventos:', error);
         throw new Error('Error fetching eventos');
       }
     },
@@ -53,7 +54,7 @@ SELECT id, "NombreEstado" as "nombreEstado", "CodigoEstado" as "codigoEstado" FR
         );
         return estado;
       } catch (error) {
-        console.error('Error fetching estado:', error);
+        logger.error('Error fetching estado:', error);
         throw new Error('Error fetching estado');
       }
     },
@@ -66,7 +67,7 @@ SELECT id, "NombreMunicipio" as "nombreMunicipio", "CodigoMunicipio" as "codigoM
         );
         return municipio;
       } catch (error) {
-        console.error('Error fetching municipio:', error);
+        logger.error('Error fetching municipio:', error);
         throw new Error('Error fetching municipio');
       }
     },
@@ -86,7 +87,7 @@ WHERE "Oid" = $1
         );
         return evento;
       } catch (error) {
-        console.error('Error fetching evento:', error);
+        logger.error('Error fetching evento:', error);
         throw new Error('Error fetching evento');
       }
     },
@@ -110,7 +111,7 @@ WHERE "Oid" = $1
         );
         return usuario;
       } catch (error) {
-        console.error('Error fetching usuario:', error);
+        logger.error('Error fetching usuario:', error);
         throw new Error('Error fetching usuario');
       }
     },
@@ -123,7 +124,7 @@ WHERE "Oid" = $1
           [parent.id]
         );
       } catch (error) {
-        console.error('Error fetching municipios:', error);
+        logger.error('Error fetching municipios:', error);
         throw new Error('Error fetching municipios');
       }
     },
@@ -137,7 +138,7 @@ WHERE "Oid" = $1
           [parent.EstadoId]
         );
       } catch (error) {
-        console.error('Error fetching estado:', error);
+        logger.error('Error fetching estado:', error);
         throw new Error('Error fetching estado');
       }
     },
@@ -148,7 +149,7 @@ WHERE "Oid" = $1
           [parent.id]
         );
       } catch (error) {
-        console.error('Error fetching colonias:', error);
+        logger.error('Error fetching colonias:', error);
         throw new Error('Error fetching colonias');
       }
     },
@@ -161,7 +162,7 @@ WHERE "Oid" = $1
           [parent.MunicipioId]
         );
       } catch (error) {
-        console.error('Error fetching municipio:', error);
+        logger.error('Error fetching municipio:', error);
         throw new Error('Error fetching municipio');
       }
     },


### PR DESCRIPTION
## Summary
- introduce simple `logger` utility with log level control
- use logger across config, middleware, resolvers, and mail helpers
- document `LOG_LEVEL` env variable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687344e0489883309dadccb223b00237