### PR TITLE
Fix duplicate TypeScript dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.17.0",
         "nodemailer": "^7.0.3",
-        "pg-promise": "^11.10.2",
-        "typescript": "^3.9.7"
+        "pg-promise": "^11.10.2"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -42,7 +41,7 @@
         "cpx": "^1.5.0",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@apollo/cache-control-types": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.17.0",
     "nodemailer": "^7.0.3",
-    "pg-promise": "^11.10.2",
-    "typescript": "^3.9.7"
+    "pg-promise": "^11.10.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -47,6 +46,6 @@
     "cpx": "^1.5.0",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.8.2"
   }
 }


### PR DESCRIPTION
## Summary
- keep only one TypeScript entry
- bump dev TypeScript to 5.8.2

## Testing
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_687344da12848330983bf8a5d2cbd331