### PR TITLE
Fix colonias SQL query typo

### DIFF
--- a/src/resolvers/queries/location.ts
+++ b/src/resolvers/queries/location.ts
@@ -66,7 +66,7 @@ export const locationQueries = {
 
   async colonias(_: any, { __ }: { __: any }, { ps }: { ps: any }) {
     try {
-      const colonias = await ps.any('SELECT id, "CodigoPostal" as "codigoPostal", "NombreColonia", as "nombreColonia", "MunicipioId" as "municipioId" FROM "Colonias" ORDER BY "NombreColonia"');
+      const colonias = await ps.any('SELECT id, "CodigoPostal" as "codigoPostal", "NombreColonia" as "nombreColonia", "MunicipioId" as "municipioId" FROM "Colonias" ORDER BY "NombreColonia"');
       return { status: true, message: 'Resultado de colonias', colonias };
     } catch (error) {
       logger.error('Error en colonias:', error);


### PR DESCRIPTION
## Summary
- fix comma typo in `colonias` resolver query

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: ENOENT: no such file or directory, open 'src/.env')*

------
https://chatgpt.com/codex/tasks/task_e_6874016bc7dc8330a35e8e7d06a098bb