### PR TITLE
Expand test coverage and add CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && npm run copy:graphql",
     "copy:graphql": "cpx \"src/graphql/**/*.graphql\" dist/graphql",
     "start:dev": "nodemon",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --check \"**/*.{ts,js,json,md}\""
   },
   "keywords": [],
   "author": "David León Gómez <dleon55@hotmail.com>",
@@ -53,6 +54,7 @@
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.11"
+    "@types/jest": "^29.5.11",
+    "prettier": "^3.2.5"
   }
 }

--- a/tests/authMiddleware.test.ts
+++ b/tests/authMiddleware.test.ts
@@ -1,0 +1,26 @@
+process.env.JWT_SECRET = 'testsecret';
+import jwt from 'jsonwebtoken';
+import { authMiddleware } from '../src/middlewares/auth';
+
+describe('authMiddleware', () => {
+  const dbMock = 'db';
+
+  it('returns nulls when no token provided', async () => {
+    const req = { headers: {}, db: dbMock } as any;
+    const result = await authMiddleware({ req } as any);
+    expect(result).toEqual({ usuarioId: null, rol: null, db: dbMock });
+  });
+
+  it('decodes valid token', async () => {
+    const token = jwt.sign({ usuarioId: '1', rol: 'ADMIN' }, 'testsecret');
+    const req = { headers: { authorization: `Bearer ${token}` }, db: dbMock } as any;
+    const result = await authMiddleware({ req } as any);
+    expect(result).toEqual({ usuarioId: '1', rol: 'ADMIN', db: dbMock });
+  });
+
+  it('handles invalid token gracefully', async () => {
+    const req = { headers: { authorization: 'Bearer invalid' }, db: dbMock } as any;
+    const result = await authMiddleware({ req } as any);
+    expect(result).toEqual({ usuarioId: null, rol: null, db: dbMock });
+  });
+});

--- a/tests/contentResolvers.test.ts
+++ b/tests/contentResolvers.test.ts
@@ -1,0 +1,18 @@
+import { contentQueries } from '../src/resolvers/queries/content';
+
+describe('contentQueries.portfolio', () => {
+  it('returns language specific data', async () => {
+    const mockFindOne = jest.fn().mockResolvedValue({ en: ['a'], es: ['b'] });
+    const mongo = { collection: jest.fn().mockReturnValue({ findOne: mockFindOne }) } as any;
+    const result = await contentQueries.portfolio(undefined, { language: 'es' }, { mongo } as any);
+    expect(result).toEqual(['b']);
+    expect(mongo.collection).toHaveBeenCalledWith('portfolio');
+  });
+
+  it('returns empty array when no data', async () => {
+    const mockFindOne = jest.fn().mockResolvedValue(null);
+    const mongo = { collection: jest.fn().mockReturnValue({ findOne: mockFindOne }) } as any;
+    const result = await contentQueries.portfolio(undefined, { language: 'es' }, { mongo } as any);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- test auth middleware token handling
- add GraphQL resolver tests
- add prettier and format script
- run lint, format and tests in CI

## Testing
- `npm test`
- `npm run lint` *(fails: 152 problems)*
- `npm run format` *(reports style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6874b1fb2a7c8330aacd5ba382b8c347