### PR TITLE
Centralize dotenv config

### DIFF
--- a/src/config/environments.ts
+++ b/src/config/environments.ts
@@ -1,10 +1,3 @@
-import dotenv from 'dotenv';
-import path from 'path';
+import env from './loadEnv';
 
-const environments = dotenv.config({
-  path: path.resolve(__dirname, '../../.env'),
-});
-
-// Ignore missing .env file in non-production environments
-
-export default environments;
+export default env;

--- a/src/config/loadEnv.ts
+++ b/src/config/loadEnv.ts
@@ -1,0 +1,9 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from project root .env file
+const env = dotenv.config({
+  path: path.resolve(__dirname, '../../.env'),
+});
+
+export default env;

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -1,9 +1,7 @@
 // src/lib/mails.ts
 import nodemailer from 'nodemailer';
-import dotenv from 'dotenv';
 import logger from './logger';
-
-dotenv.config();
+import '../config/loadEnv';
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,

--- a/src/middlewares/recaptcha.ts
+++ b/src/middlewares/recaptcha.ts
@@ -1,7 +1,6 @@
 import { RecaptchaEnterpriseServiceClient } from '@google-cloud/recaptcha-enterprise';
-import dotenv from 'dotenv';
 import logger from '../lib/logger';
-dotenv.config();
+import '../config/loadEnv';
 
 export async function verificarTokenReCaptcha(token: string): Promise<boolean> {
   const projectId = process.env.RECAPTCHA_PROJECT_ID!;


### PR DESCRIPTION
## Summary
- load environment variables from a single module
- use the centralized loader across the codebase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68754f781b3883309b1a1d880f30755c